### PR TITLE
Add recent rooms, improve UX and refactor frontend

### DIFF
--- a/frontend/src/app.rs
+++ b/frontend/src/app.rs
@@ -25,7 +25,6 @@ use crate::stores::{RoomStore, UserStore, VoteStore};
 use crate::ws::WsContext;
 use leptos::prelude::*;
 use leptos_router::components::{Route, Router, Routes};
-use leptos_router::hooks::use_location;
 use leptos_router::path;
 
 #[component]
@@ -61,18 +60,13 @@ pub fn App() -> impl IntoView {
 
 #[component]
 fn ContentRouter() -> impl IntoView {
-    let location = use_location();
-    let pathname = move || location.pathname.get();
-
     view! {
+        <MainPage />
         <Routes fallback=|| "Not found">
             <Route path=path!("/room/:room_name/:password") view=ConnectingPage />
             <Route path=path!("/error/:error_type") view=ErrorPage />
             <Route path=path!("/") view=|| () />
         </Routes>
-        <Show when=move || pathname() == "/">
-            <MainPage />
-        </Show>
     }
 }
 

--- a/frontend/src/app.rs
+++ b/frontend/src/app.rs
@@ -20,12 +20,12 @@ use crate::components::main_menu::MainMenu;
 use crate::components::no_menu::NoMenu;
 use crate::pages::connecting::ConnectingPage;
 use crate::pages::error::ErrorPage;
-use crate::pages::home::HomePage;
 use crate::pages::main_view::MainPage;
 use crate::stores::{RoomStore, UserStore, VoteStore};
 use crate::ws::WsContext;
 use leptos::prelude::*;
 use leptos_router::components::{Route, Router, Routes};
+use leptos_router::hooks::use_location;
 use leptos_router::path;
 
 #[component]
@@ -51,16 +51,28 @@ pub fn App() -> impl IntoView {
                         <MenuRouter />
                     </nav>
                     <main class="app-content">
-                        <Routes fallback=|| "Not found">
-                            <Route path=path!("/") view=HomePage />
-                            <Route path=path!("/main") view=MainPage />
-                            <Route path=path!("/room/:room_name/:password") view=ConnectingPage />
-                            <Route path=path!("/error/:error_type") view=ErrorPage />
-                        </Routes>
+                        <ContentRouter />
                     </main>
                 </div>
             </div>
         </Router>
+    }
+}
+
+#[component]
+fn ContentRouter() -> impl IntoView {
+    let location = use_location();
+    let pathname = move || location.pathname.get();
+
+    view! {
+        <Routes fallback=|| "Not found">
+            <Route path=path!("/room/:room_name/:password") view=ConnectingPage />
+            <Route path=path!("/error/:error_type") view=ErrorPage />
+            <Route path=path!("/") view=|| () />
+        </Routes>
+        <Show when=move || pathname() == "/">
+            <MainPage />
+        </Show>
     }
 }
 

--- a/frontend/src/components/dialogs.rs
+++ b/frontend/src/components/dialogs.rs
@@ -26,9 +26,26 @@ pub fn PromptDialog(
     title: &'static str,
     #[prop(default = &[])] content: &'static [&'static str],
     show: RwSignal<bool>,
+    #[prop(optional, into)] initial_value: Option<Signal<String>>,
     on_confirm: Callback<String>,
 ) -> impl IntoView {
     let input_value = RwSignal::new(String::new());
+    let input_ref: NodeRef<leptos::html::Input> = NodeRef::new();
+
+    // Populate initial value and focus when dialog opens
+    Effect::new(move |_| {
+        if show.get() {
+            if let Some(iv) = initial_value {
+                input_value.set(iv.get_untracked());
+            }
+            request_animation_frame(move || {
+                if let Some(el) = input_ref.get() {
+                    let _ = el.focus();
+                    let _ = el.select();
+                }
+            });
+        }
+    });
 
     let on_submit = move || {
         let val = input_value.get();
@@ -62,6 +79,7 @@ pub fn PromptDialog(
                             type="text"
                             class="dialog-input"
                             aria-labelledby="prompt-dialog-title"
+                            node_ref=input_ref
                             prop:value=move || input_value.get()
                             on:input=move |e| {
                                 let target: HtmlInputElement = event_target(&e);
@@ -92,6 +110,17 @@ pub fn RoomDialog(
 ) -> impl IntoView {
     let room_name = RwSignal::new(String::new());
     let room_password = RwSignal::new(String::new());
+    let room_name_ref: NodeRef<leptos::html::Input> = NodeRef::new();
+
+    Effect::new(move |_| {
+        if show.get() {
+            request_animation_frame(move || {
+                if let Some(el) = room_name_ref.get() {
+                    let _ = el.focus();
+                }
+            });
+        }
+    });
 
     let on_submit = move || {
         let name = room_name.get();
@@ -134,6 +163,7 @@ pub fn RoomDialog(
                                 id="room-name-input"
                                 type="text"
                                 class="dialog-input"
+                                node_ref=room_name_ref
                                 prop:value=move || room_name.get()
                                 on:input=move |e| {
                                     let target: HtmlInputElement = event_target(&e);

--- a/frontend/src/components/main_menu.rs
+++ b/frontend/src/components/main_menu.rs
@@ -17,6 +17,7 @@
  */
 
 use crate::components::dialogs::{PromptDialog, RoomDialog};
+use crate::components::room_list::{leave_all_and_join, RoomList};
 use crate::stores::{RoomStore, UserStore, VoteStore};
 use crate::ws;
 use leptos::prelude::*;
@@ -45,10 +46,6 @@ pub fn MainMenu() -> impl IntoView {
         }).unwrap_or_default()
     });
 
-    let rooms = Memo::new(move |_| {
-        room_store.rooms_signal().get()
-    });
-
     // Register on creation
     ws::ws_register();
 
@@ -57,6 +54,10 @@ pub fn MainMenu() -> impl IntoView {
             <PromptDialog
                 title="What's your name?"
                 show=show_name_dialog
+                initial_value=Signal::derive(move || {
+                    let n = name.get();
+                    if n == "Shirtless Muppet" || n == "not connected" { String::new() } else { n }
+                })
                 on_confirm=Callback::new(move |name: String| {
                     ws::ws_set_name(name);
                 })
@@ -74,8 +75,8 @@ pub fn MainMenu() -> impl IntoView {
             />
             <RoomDialog
                 show=show_room_dialog
-                on_confirm=Callback::new(|(room_name, password): (String, String)| {
-                    ws::ws_join_room(room_name, password, false);
+                on_confirm=Callback::new(move |(room_name, password): (String, String)| {
+                    leave_all_and_join(room_store, vote_store, room_name, password, false);
                 })
             />
 
@@ -124,50 +125,7 @@ pub fn MainMenu() -> impl IntoView {
                 </div>
             </div>
 
-            <div id="menu-rooms">
-                <header>
-                    "Rooms"
-                    <button class="btn btn-icon btn-primary" aria-label="Create or join a room" on:click=move |_| show_room_dialog.set(true)>
-                        <span class="material-icons" aria-hidden="true">"add"</span>
-                    </button>
-                </header>
-                <Show when=move || rooms.get().is_empty()>
-                    <div class="card">
-                        <div class="card-content">
-                            "Yes, the \"+\" over here"
-                        </div>
-                    </div>
-                </Show>
-                <div id="room-list">
-                    <For
-                        each=move || rooms.get()
-                        key=|room| room.room_name.clone()
-                        let:room
-                    >
-                        {
-                            let rn = room.room_name.clone();
-                            let rn2 = room.room_name.clone();
-                            view! {
-                                <div class="card">
-                                    <div class="card-header">
-                                        <div class="card-title">{rn.clone()}</div>
-                                    </div>
-                                    <div class="card-content">
-                                        "Voting: " {room.votes_cast} "/" {room.users.len()}
-                                    </div>
-                                    <div class="card-actions">
-                                        <button class="btn" on:click=move |_| {
-                                            ws::ws_leave_room(rn2.clone());
-                                            room_store.leave_room(&rn2);
-                                            vote_store.leave_room(&rn2);
-                                        }>"Leave"</button>
-                                    </div>
-                                </div>
-                            }
-                        }
-                    </For>
-                </div>
-            </div>
+            <RoomList show_room_dialog=show_room_dialog />
         </div>
     }
 }

--- a/frontend/src/components/mod.rs
+++ b/frontend/src/components/mod.rs
@@ -19,6 +19,7 @@
 pub mod gravatar;
 pub mod user_card;
 pub mod room;
+pub mod room_list;
 pub mod main_menu;
 pub mod no_menu;
 pub mod dialogs;

--- a/frontend/src/components/room.rs
+++ b/frontend/src/components/room.rs
@@ -85,26 +85,26 @@ pub fn Room(room_name: String) -> impl IntoView {
             <div class="card-header header">
                 <div class="card-title">
                     {room_name_display} " - " {move || room_link.get()}
-                </div>
-                <button
-                    class="btn btn-icon"
-                    style="color: #fff; margin-left: auto;"
-                    title="Copy room link"
-                    aria-label="Copy room link"
-                    on:click=move |_| {
-                        let link = room_link.get();
-                        if let Some(window) = web_sys::window() {
-                            let clipboard = window.navigator().clipboard();
-                            let _ = clipboard.write_text(&link);
-                            link_copied.set(true);
-                            set_timeout(move || link_copied.set(false), std::time::Duration::from_secs(2));
+                    <button
+                        class="btn btn-icon"
+                        style="color: #fff;"
+                        title="Copy room link"
+                        aria-label="Copy room link"
+                        on:click=move |_| {
+                            let link = room_link.get();
+                            if let Some(window) = web_sys::window() {
+                                let clipboard = window.navigator().clipboard();
+                                let _ = clipboard.write_text(&link);
+                                link_copied.set(true);
+                                set_timeout(move || link_copied.set(false), std::time::Duration::from_secs(2));
+                            }
                         }
-                    }
-                >
-                    <span class="material-icons" aria-hidden="true">
-                        {move || if link_copied.get() { "check" } else { "link" }}
-                    </span>
-                </button>
+                    >
+                        <span class="material-icons" aria-hidden="true">
+                            {move || if link_copied.get() { "check" } else { "link" }}
+                        </span>
+                    </button>
+                </div>
             </div>
             <div class="card-content user-space">
                 <For

--- a/frontend/src/components/room_list.rs
+++ b/frontend/src/components/room_list.rs
@@ -1,0 +1,185 @@
+/*
+ * SizeMatters - a ticket sizing util
+ * Copyright (C) 2026 Andre Onuki
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+use crate::storage;
+use crate::storage::RecentRoom;
+use crate::stores::{RoomStore, VoteStore};
+use crate::ws;
+use leptos::prelude::*;
+
+pub fn leave_all_and_join(room_store: RoomStore, vote_store: VoteStore, room_name: String, password: String, password_is_hash: bool) {
+    let active = room_store.rooms_signal().get_untracked();
+    for r in &active {
+        ws::ws_leave_room(r.room_name.clone());
+        room_store.leave_room(&r.room_name);
+        vote_store.leave_room(&r.room_name);
+    }
+    ws::ws_join_room(room_name, password, password_is_hash);
+}
+
+#[component]
+pub fn RoomList(
+    show_room_dialog: RwSignal<bool>,
+) -> impl IntoView {
+    let room_store = expect_context::<RoomStore>();
+
+    let rooms = Memo::new(move |_| room_store.rooms_signal().get());
+
+    let recent_rooms = RwSignal::new(storage::load_recent_rooms());
+
+    // Refresh recent rooms whenever active rooms change
+    Effect::new(move |_| {
+        let _ = room_store.rooms_signal().get();
+        recent_rooms.set(storage::load_recent_rooms());
+    });
+
+    // Recent rooms that aren't currently joined
+    let filtered_recent = Memo::new(move |_| {
+        let active: Vec<String> = rooms.get().iter().map(|r| r.room_name.clone()).collect();
+        recent_rooms.get().into_iter().filter(|r| !active.contains(&r.room_name)).collect::<Vec<RecentRoom>>()
+    });
+
+    view! {
+        <div id="menu-rooms">
+            <header>
+                "Rooms"
+                <button class="btn btn-icon btn-primary" aria-label="Create or join a room" on:click=move |_| show_room_dialog.set(true)>
+                    <span class="material-icons" aria-hidden="true">"add"</span>
+                </button>
+            </header>
+            <Show when=move || rooms.get().is_empty() && filtered_recent.get().is_empty()>
+                <div class="card">
+                    <div class="card-content">
+                        "Yes, the \"+\" over here"
+                    </div>
+                </div>
+            </Show>
+            <div id="room-list">
+                <For
+                    each=move || rooms.get()
+                    key=|room| room.room_name.clone()
+                    let:room
+                >
+                    <ActiveRoomItem room_name=room.room_name.clone() />
+                </For>
+            </div>
+
+            <Show when=move || !filtered_recent.get().is_empty()>
+                <div id="recent-room-list">
+                    <For
+                        each=move || filtered_recent.get()
+                        key=|room| room.room_name.clone()
+                        let:room
+                    >
+                        <RecentRoomItem
+                            room_name=room.room_name.clone()
+                            hashed_password=room.hashed_password.clone()
+                            recent_rooms=recent_rooms
+                        />
+                    </For>
+                </div>
+            </Show>
+        </div>
+    }
+}
+
+#[component]
+fn ActiveRoomItem(
+    room_name: String,
+) -> impl IntoView {
+    let room_store = expect_context::<RoomStore>();
+    let vote_store = expect_context::<VoteStore>();
+    let rn = room_name.clone();
+    let rn2 = room_name.clone();
+
+    let room_status = Memo::new(move |_| {
+        room_store.rooms_signal().get()
+            .into_iter()
+            .find(|r| r.room_name == rn)
+    });
+
+    view! {
+        <div class="card">
+            <div class="card-header">
+                <div class="card-title">{room_name}</div>
+            </div>
+            <div class="card-content">
+                "Voting: "
+                {move || room_status.get().map(|r| r.votes_cast).unwrap_or(0)}
+                "/"
+                {move || room_status.get().map(|r| r.users.len()).unwrap_or(0)}
+            </div>
+            <div class="card-actions">
+                <button class="btn" on:click=move |_| {
+                    ws::ws_leave_room(rn2.clone());
+                    room_store.leave_room(&rn2);
+                    vote_store.leave_room(&rn2);
+                }>"Leave"</button>
+            </div>
+        </div>
+    }
+}
+
+#[component]
+fn RecentRoomItem(
+    room_name: String,
+    hashed_password: String,
+    recent_rooms: RwSignal<Vec<RecentRoom>>,
+) -> impl IntoView {
+    let room_store = expect_context::<RoomStore>();
+    let vote_store = expect_context::<VoteStore>();
+    let rn = room_name.clone();
+    let hp = hashed_password.clone();
+    let rn2 = room_name.clone();
+    let hp2 = hashed_password.clone();
+    let rn_delete = room_name.clone();
+
+    let room_name_label = format!("Rejoin room {}", room_name);
+    view! {
+        <div
+            class="card recent-room"
+            role="button"
+            tabindex="0"
+            aria-label=room_name_label
+            on:click=move |_| {
+                leave_all_and_join(room_store, vote_store, rn.clone(), hp.clone(), true);
+            }
+            on:keydown=move |e: web_sys::KeyboardEvent| {
+                if e.key() == "Enter" || e.key() == " " {
+                    e.prevent_default();
+                    leave_all_and_join(room_store, vote_store, rn2.clone(), hp2.clone(), true);
+                }
+            }
+        >
+            <div class="card-content">
+                <span>{room_name}</span>
+                <button
+                    class="btn btn-icon recent-room-delete"
+                    aria-label="Remove from recent rooms"
+                    on:click=move |e| {
+                        e.stop_propagation();
+                        storage::remove_recent_room(&rn_delete);
+                        recent_rooms.set(storage::load_recent_rooms());
+                    }
+                >
+                    <span class="material-icons" aria-hidden="true">"delete"</span>
+                </button>
+            </div>
+        </div>
+    }
+}

--- a/frontend/src/lib.rs
+++ b/frontend/src/lib.rs
@@ -18,6 +18,7 @@
 
 mod app;
 mod ws;
+mod storage;
 mod stores;
 mod pages;
 mod components;

--- a/frontend/src/pages/connecting.rs
+++ b/frontend/src/pages/connecting.rs
@@ -56,7 +56,7 @@ pub fn ConnectingPage() -> impl IntoView {
             if !rn2.is_empty() && !pw2.is_empty() {
                 ws::ws_join_room(rn2.clone(), pw2.clone(), true);
             }
-            nav2("/main", Default::default());
+            nav2("/", Default::default());
         }
     });
 

--- a/frontend/src/pages/main_view.rs
+++ b/frontend/src/pages/main_view.rs
@@ -35,7 +35,7 @@ pub fn MainPage() -> impl IntoView {
     });
 
     let banner_dismissed = RwSignal::new(false);
-    let rooms = Memo::new(move |_| room_store.rooms_signal().get());
+    let rooms = room_store.rooms_signal();
     let last_error = ws_ctx.last_error();
 
     let dismiss_banner = move |_| {
@@ -78,16 +78,10 @@ pub fn MainPage() -> impl IntoView {
             </Show>
 
             <div id="rooms">
-                <For
-                    each=move || rooms.get()
-                    key=|room| room.room_name.clone()
-                    let:room
-                >
-                    {
-                        let rn = room.room_name.clone();
-                        view! { <Room room_name=rn /> }
-                    }
-                </For>
+                {move || rooms.get().iter().map(|room| {
+                    let rn = room.room_name.clone();
+                    view! { <Room room_name=rn /> }
+                }).collect_view()}
 
                 <Show when=move || rooms.get().is_empty()>
                     <div class="empty-state">

--- a/frontend/src/storage.rs
+++ b/frontend/src/storage.rs
@@ -1,0 +1,98 @@
+/*
+ * SizeMatters - a ticket sizing util
+ * Copyright (C) 2026 Andre Onuki
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+use web_sys::Storage;
+
+fn local_storage() -> Option<Storage> {
+    web_sys::window().and_then(|w| w.local_storage().ok().flatten())
+}
+
+// User profile
+
+pub fn save_name(name: &str) {
+    if let Some(storage) = local_storage() {
+        let _ = storage.set_item("name", name);
+    }
+}
+
+pub fn load_name() -> Option<String> {
+    local_storage().and_then(|s| s.get_item("name").ok().flatten())
+}
+
+pub fn save_avatar(email: &str) {
+    if let Some(storage) = local_storage() {
+        let _ = storage.set_item("avatar", email);
+    }
+}
+
+pub fn load_avatar() -> Option<String> {
+    local_storage().and_then(|s| s.get_item("avatar").ok().flatten())
+}
+
+// Recent rooms
+
+const RECENT_ROOMS_KEY: &str = "recent_rooms";
+const MAX_RECENT_ROOMS: usize = 10;
+
+#[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct RecentRoom {
+    pub room_name: String,
+    pub hashed_password: String,
+}
+
+pub fn save_recent_room(room_name: &str, hashed_password: &str) {
+    let storage = match local_storage() {
+        Some(s) => s,
+        None => return,
+    };
+
+    let mut rooms = load_recent_rooms();
+
+    // Remove if already exists (will re-add at front)
+    rooms.retain(|r| r.room_name != room_name);
+    rooms.insert(0, RecentRoom {
+        room_name: room_name.to_string(),
+        hashed_password: hashed_password.to_string(),
+    });
+    rooms.truncate(MAX_RECENT_ROOMS);
+
+    if let Ok(json) = serde_json::to_string(&rooms) {
+        let _ = storage.set_item(RECENT_ROOMS_KEY, &json);
+    }
+}
+
+pub fn remove_recent_room(room_name: &str) {
+    let storage = match local_storage() {
+        Some(s) => s,
+        None => return,
+    };
+
+    let mut rooms = load_recent_rooms();
+    rooms.retain(|r| r.room_name != room_name);
+
+    if let Ok(json) = serde_json::to_string(&rooms) {
+        let _ = storage.set_item(RECENT_ROOMS_KEY, &json);
+    }
+}
+
+pub fn load_recent_rooms() -> Vec<RecentRoom> {
+    local_storage()
+        .and_then(|s| s.get_item(RECENT_ROOMS_KEY).ok().flatten())
+        .and_then(|json| serde_json::from_str(&json).ok())
+        .unwrap_or_default()
+}

--- a/frontend/src/ws.rs
+++ b/frontend/src/ws.rs
@@ -204,14 +204,11 @@ fn send_message(msg: ClientRequestMessage) {
 
 /// Restore user name and avatar from localStorage after reconnecting.
 fn restore_data() {
-    let storage = web_sys::window().unwrap().local_storage().unwrap();
-    if let Some(storage) = storage {
-        if let Ok(Some(name)) = storage.get_item("name") {
-            send_message(ClientRequestMessage::SetName { name });
-        }
-        if let Ok(Some(avatar)) = storage.get_item("avatar") {
-            send_message(ClientRequestMessage::SetAvatar { avatar });
-        }
+    if let Some(name) = crate::storage::load_name() {
+        send_message(ClientRequestMessage::SetName { name });
+    }
+    if let Some(avatar) = crate::storage::load_avatar() {
+        send_message(ClientRequestMessage::SetAvatar { avatar });
     }
 }
 
@@ -250,6 +247,7 @@ fn process_message(
             users,
             votes_cast,
         } => {
+            crate::storage::save_recent_room(&room_name, &hashed_password);
             let user_ids: Vec<String> = users.iter().map(|u| u.user_id.clone()).collect();
             user_store.room_joined(&users);
             vote_store.room_joined(&room_name, &user_ids, votes_cast);
@@ -321,18 +319,12 @@ pub fn ws_register() {
 }
 
 pub fn ws_set_name(name: String) {
-    let storage = web_sys::window().unwrap().local_storage().unwrap();
-    if let Some(storage) = storage {
-        let _ = storage.set_item("name", &name);
-    }
+    crate::storage::save_name(&name);
     send_message(ClientRequestMessage::SetName { name });
 }
 
 pub fn ws_set_avatar(email: String) {
-    let storage = web_sys::window().unwrap().local_storage().unwrap();
-    if let Some(storage) = storage {
-        let _ = storage.set_item("avatar", &email);
-    }
+    crate::storage::save_avatar(&email);
     send_message(ClientRequestMessage::SetAvatar { avatar: email });
 }
 

--- a/frontend/style/main.css
+++ b/frontend/style/main.css
@@ -308,8 +308,22 @@ html, body {
     position: relative;
 }
 
+.user-card .card-title {
+    height: 3.6em;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
 .user-card .name {
     font-size: 24px;
+    line-height: 1.3;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    word-break: break-all;
 }
 
 .user-card .user-pic {

--- a/frontend/style/main.css
+++ b/frontend/style/main.css
@@ -225,6 +225,39 @@ html, body {
     margin-top: 16px;
 }
 
+/* Recent rooms */
+#recent-room-list {
+    margin-top: 8px;
+}
+
+#recent-room-list .card {
+    cursor: pointer;
+}
+
+#recent-room-list .card + .card {
+    margin-top: 8px;
+}
+
+#recent-room-list .card:hover {
+    background-color: #e0e0e0;
+}
+
+#recent-room-list .card-content {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+}
+
+.recent-room-delete {
+    opacity: 0;
+    transition: opacity 0.2s;
+}
+
+#recent-room-list .card:hover .recent-room-delete,
+#recent-room-list .card:focus-within .recent-room-delete {
+    opacity: 1;
+}
+
 /* Room component */
 .room + .room {
     margin-top: 16px;
@@ -236,8 +269,12 @@ html, body {
 }
 
 .room .header .card-title {
-    font-size: 14px;
+    font-size: 16px;
     word-break: break-all;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-wrap: wrap;
 }
 
 .room .user-space {
@@ -272,7 +309,7 @@ html, body {
 }
 
 .user-card .name {
-    font-size: 14px;
+    font-size: 24px;
 }
 
 .user-card .user-pic {


### PR DESCRIPTION
## Summary
- Save recently visited rooms to localStorage (up to 10) and show them in the sidebar with click-to-rejoin and trash icon to remove
- Leave current room before joining a new one, fixing CannotJoinMultipleRooms error
- Replace route-based `/main` content switching with a reactive `DefaultView` that shows rooms when joined, fixing rooms not appearing in main content area
- Move copy-link button inline next to room link, center room title, increase font size
- Auto-focus input when name and room dialogs open; pre-fill name dialog with current name
- Only show "Yes, the + over here" when no rooms and no recent rooms exist
- Extract `storage.rs` module for all localStorage operations (user profile + recent rooms)
- Extract `RoomList`, `ActiveRoomItem`, `RecentRoomItem` components from `MainMenu`
- Extract `leave_all_and_join` helper to eliminate duplicated room-switching logic

## Test plan
- [ ] Create a room, verify it appears in main content area and sidebar
- [ ] Leave the room, verify it appears in the recent rooms list
- [ ] Click a recent room to rejoin, verify leave-before-join works
- [ ] Click trash icon on a recent room, verify it's removed from the list
- [ ] Create a room while already in one, verify old room is left first
- [ ] Open name dialog, verify input is focused and pre-filled with current name
- [ ] Open room dialog, verify room name input is focused
- [ ] Verify vote count updates live in sidebar room cards
- [ ] Join via shared link (/room/:name/:password), verify redirect to main view